### PR TITLE
Add test & method for board init

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,12 +1,13 @@
 class Board
     attr_reader :cells
 
-    def initialize(cells)
-        @cells = cells
+    def initialize
+       @cells = Hash.new("na")
+       new_board
     end
 
     def valid_coordinate?(coord)
-        @cells.find do |cell|
+        @cells.find do |coordinate, cell|
             if cell.coordinate == coord
                 return true
             end
@@ -14,5 +15,14 @@ class Board
         end
         false
         # @cells.find {|cell| cell.coordinate == coord ? true : false}
+    end
+
+    def new_board(end_row = "D",end_column = 4)
+        ("A"..end_row).to_a.each do |letter|
+            (1..end_column).to_a.each do |num|
+                coordinate = "#{letter}#{num}"
+                @cells["#{coordinate}"] = Cell.new(coordinate)
+            end
+        end
     end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -2,27 +2,36 @@ require 'spec_helper'
 
 RSpec.describe Board do
     before(:each) do
-      A1 = Cell.new("A1")
-      A2 = Cell.new("A2")
-      A3 = Cell.new("A3")
-      B1 = Cell.new("B1")
-      B2 = Cell.new("B2")
-      B3 = Cell.new("B3")
-      C1 = Cell.new("C1")
-      C2 = Cell.new("C2")
-      C3 = Cell.new("C3")
-      @cells = [A1, A2, A3, B1, B2, B3, C1, C2, C3]
-      @board = Board.new(@cells)
+    #   A1 = Cell.new("A1")
+    #   A2 = Cell.new("A2")
+    #   A3 = Cell.new("A3")
+    #   B1 = Cell.new("B1")
+    #   B2 = Cell.new("B2")
+    #   B3 = Cell.new("B3")
+    #   C1 = Cell.new("C1")
+    #   C2 = Cell.new("C2")
+    #   C3 = Cell.new("C3")
+    #   @cells = [A1, A2, A3, B1, B2, B3, C1, C2, C3]
+    #   @board = Board.new(@cells)
+      @board = Board.new
       @cruiser = Ship.new("Cruiser", 3)
       @submarine = Ship.new("Submarine", 2)
     end
 
     describe 'Initialize' do
         it 'exists' do
+            expect(@board).to be_an_instance_of Board
         end
 
-        it 'creates board' do
+        it 'creates board cells, and its equal to a hash' do
+            expect(@board.cells).to be_truthy
+            expect(@board.cells.class).to eq(Hash)
         end
+        it 'The board cells values are cell objects ' do
+            expect(@board.cells["A1"]).to be_an_instance_of Cell
+            expect(@board.cells["A1"].coordinate).to eq("A1")
+        end
+
     end
 
     describe '#valid_coordinate?' do


### PR DESCRIPTION
**Board Init**
functionality: the board init has a method new_board that creates a hash for coordinates as keys & cell objects as values

Test: Created 3 test:

- To check if it initialize
- To Check if cells contains a value
- To Check if cells are created appropriately